### PR TITLE
Csv testing

### DIFF
--- a/paxwatcher.py
+++ b/paxwatcher.py
@@ -65,8 +65,8 @@ def onReceive(packet, interface):
             # here we build the array for what gets appended to the csv
             add_data = [now_time, who_from, message.uptime, packet['rxSnr'], message.wifi, message.ble, paxtotal]
             # open the file we saved OnConnect, in append mode, and we want newlines after each new tranche of data
-            with open(f'{fileprefix}_{timestamp}.csv', 'a', newline='\n') as f:
-                writer = csv.writer(file) # type: ignore
+            with open(f'{fileprefix}_{timestamp}.csv', 'a', newline='\n') as file:
+                writer = csv.writer(file)
                 writer.writerow(add_data)
             # also print all that to the screen in a structured format
             print(f"*          {packet['decoded'].get('portnum', 'N/A')} packet")

--- a/paxwatcher.py
+++ b/paxwatcher.py
@@ -1,5 +1,7 @@
 # 
-# this connects to the specified node via IP, then prints every PaxCount packet to the screen, and logs to a csv file
+# this connects to the specified node via IP, 
+#  then prints every PaxCount packet to the screen
+#  and logs to a csv file
 # 
 import meshtastic.tcp_interface # type: ignore
 from meshtastic.serial_interface import SerialInterface # type: ignore
@@ -64,7 +66,7 @@ def onReceive(packet, interface):
             add_data = [now_time, who_from, message.uptime, packet['rxSnr'], message.wifi, message.ble, paxtotal]
             # open the file we saved OnConnect, in append mode, and we want newlines after each new tranche of data
             with open(f'{fileprefix}_{timestamp}.csv', 'a', newline='\n') as f:
-                writer = csv.writer(file)
+                writer = csv.writer(file) # type: ignore
                 writer.writerow(add_data)
             # also print all that to the screen in a structured format
             print(f"*          {packet['decoded'].get('portnum', 'N/A')} packet")

--- a/paxwatcher.py
+++ b/paxwatcher.py
@@ -9,6 +9,7 @@ from datetime import datetime
 import pytz # type: ignore
 import time
 import csv
+# test
 #
 # replace with your nodes IP
 #


### PR DESCRIPTION
completed testing on added csv functionality, iterated 11 times 

new file is created when script is run, and is named [prefix]_[unix timestamp] 

each time a PaxCounter packet is received, in addition to displaying on the screen, 
we append a new row to the csv, consisting of
[timestamp],[from],[uptime],[SNR],[wifi count], [BLE count], [total count]